### PR TITLE
[FIX] Ensure Consistency of Representative Spec

### DIFF
--- a/spec/models/representative_spec.rb
+++ b/spec/models/representative_spec.rb
@@ -65,9 +65,9 @@ describe Representative do
   end
 
   describe 'get_representatives_by_ocdid' do
-    it 'returns a the correct representatives' do
+    it 'returns the correct representative' do
       result = described_class.get_representatives_by_ocdid('ocd-division/country:us/state:ca/county:sacramento')
-      test_rep = result.find(name: 'Jim Cooper').first
+      test_rep = result.filter { |rep| rep.name == 'Jim Cooper'}.first
       expect(test_rep.name).to eq('Jim Cooper')
       expect(test_rep.party).to eq('Nonpartisan')
       expect(test_rep.photo_url).to be_nil


### PR DESCRIPTION
# Changes

- Use `filter` instead of `find` to search for the proper candidate.

closes #32